### PR TITLE
Issue #5: phased lint strategy + changed-file lint gate

### DIFF
--- a/.github/workflows/lint-changed.yml
+++ b/.github/workflows/lint-changed.yml
@@ -1,0 +1,34 @@
+name: Lint Changed Files
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  lint-changed:
+    name: lint-changed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer:v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          composer install --no-interaction --prefer-dist
+          npm ci
+
+      - name: Lint changed files only
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: npm run lint:changed

--- a/bin/lint-changed
+++ b/bin/lint-changed
@@ -5,7 +5,8 @@ BASE_REF="${BASE_REF:-origin/develop}"
 
 if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   echo "[lint-changed] BASE_REF '$BASE_REF' not found; fetching..."
-  git fetch origin develop --depth=1
+  BASE_BRANCH="${BASE_REF#origin/}"
+  git fetch origin "$BASE_BRANCH" --depth=1
 fi
 
 CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE_REF"...HEAD)

--- a/bin/lint-changed
+++ b/bin/lint-changed
@@ -9,23 +9,30 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   git fetch origin "$BASE_BRANCH" --depth=1
 fi
 
-CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE_REF"...HEAD)
+declare -a PHP_FILES=()
+declare -a JS_FILES=()
 
-PHP_FILES=$(echo "$CHANGED" | grep -E '\.php$' || true)
-JS_FILES=$(echo "$CHANGED" | grep -E '\.(js|jsx|mjs|cjs)$' || true)
+while IFS= read -r -d '' file; do
+  case "$file" in
+    *.php)
+      PHP_FILES+=("$file")
+      ;;
+    *.js|*.jsx|*.mjs|*.cjs)
+      JS_FILES+=("$file")
+      ;;
+  esac
+done < <(git diff --name-only -z --diff-filter=ACMRT "$BASE_REF"...HEAD)
 
-if [[ -n "$PHP_FILES" ]]; then
+if ((${#PHP_FILES[@]})); then
   echo "[lint-changed] Running PHPCS on changed PHP files"
-  # shellcheck disable=SC2086
-  vendor/bin/phpcs $PHP_FILES
+  vendor/bin/phpcs "${PHP_FILES[@]}"
 else
   echo "[lint-changed] No changed PHP files"
 fi
 
-if [[ -n "$JS_FILES" ]]; then
+if ((${#JS_FILES[@]})); then
   echo "[lint-changed] Running ESLint via wp-scripts on changed JS files"
-  # shellcheck disable=SC2086
-  npx wp-scripts lint-js $JS_FILES
+  npx wp-scripts lint-js "${JS_FILES[@]}"
 else
   echo "[lint-changed] No changed JS files"
 fi

--- a/bin/lint-changed
+++ b/bin/lint-changed
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/develop}"
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "[lint-changed] BASE_REF '$BASE_REF' not found; fetching..."
+  git fetch origin develop --depth=1
+fi
+
+CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE_REF"...HEAD)
+
+PHP_FILES=$(echo "$CHANGED" | grep -E '\.php$' || true)
+JS_FILES=$(echo "$CHANGED" | grep -E '\.(js|jsx|mjs|cjs)$' || true)
+
+if [[ -n "$PHP_FILES" ]]; then
+  echo "[lint-changed] Running PHPCS on changed PHP files"
+  # shellcheck disable=SC2086
+  vendor/bin/phpcs $PHP_FILES
+else
+  echo "[lint-changed] No changed PHP files"
+fi
+
+if [[ -n "$JS_FILES" ]]; then
+  echo "[lint-changed] Running ESLint via wp-scripts on changed JS files"
+  # shellcheck disable=SC2086
+  npx wp-scripts lint-js $JS_FILES
+else
+  echo "[lint-changed] No changed JS files"
+fi

--- a/docs/lint-baseline.md
+++ b/docs/lint-baseline.md
@@ -1,0 +1,10 @@
+# Lint baseline (placeholder)
+
+Create this baseline after running full lint and collecting current violations.
+
+Suggested format:
+
+- PHPCS: `<count>`
+- JS lint: `<count>`
+- Date captured: `<YYYY-MM-DD>`
+- Owner: `<name>`

--- a/docs/lint-debt-reduction-plan.md
+++ b/docs/lint-debt-reduction-plan.md
@@ -1,0 +1,35 @@
+# Lint debt reduction plan
+
+This project will enforce lint in phases so contributors can keep shipping while we burn down legacy violations.
+
+## Phase 1 (now): changed-file lint gate
+
+- CI runs `lint-changed` on every PR.
+- Only files touched in the PR are lint-gated.
+- Goal: no new lint debt.
+
+## Phase 2 (by 2026-03-15): baseline capture
+
+- Capture current full-repo lint violations into a baseline record (`docs/lint-baseline.md`).
+- Categorize by type:
+  - PHPCS
+  - JS lint
+- Track counts and owners.
+
+## Phase 3 (2026-03-15 to 2026-05-15): burn-down
+
+Milestones:
+
+1. **M1 (2026-03-31)**: reduce baseline by 25%
+2. **M2 (2026-04-30)**: reduce baseline by 60%
+3. **M3 (2026-05-15)**: reduce baseline by 90%+
+
+## Phase 4 (target: 2026-06-01): full strict lint
+
+- Switch CI from changed-file lint to full-repo strict lint as required checks.
+- Keep `lint-changed` available for fast local feedback.
+
+## Commands
+
+- Changed files: `npm run lint:changed`
+- Full lint: `npm run lint`

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:css": "wp-scripts lint-style",
     "lint:php": "composer lint",
     "lint:php:fix": "composer lint:fix",
+    "lint:changed": "bin/lint-changed",
     "composer:cleanup": "composer install --prefer-dist --optimize-autoloader --no-dev",
     "predeploy": "npm run lint && npm run build && npm run composer:cleanup",
     "deploy": "npm run plugin-zip"


### PR DESCRIPTION
Closes #5

## What changed
- Added `bin/lint-changed` to lint only changed PHP/JS files against the PR base branch.
- Added CI workflow `.github/workflows/lint-changed.yml` to enforce the changed-file lint gate on PRs.
- Added lint debt docs:
  - `docs/lint-debt-reduction-plan.md`
  - `docs/lint-baseline.md`

## Acceptance criteria mapping
- Changed-file lint gate exists in CI ✅
- Baseline strategy documented / baseline file added ✅
- Burn-down milestones defined ✅
- Full lint enforcement target date set ✅ (2026-06-01)
