### PR TITLE
Issue #6: one-command bootstrap + standard make tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,15 @@ This document is a lightweight contributor guide for day-to-day development on t
 
 - PHP 8.1+
 - WordPress 6.9+
-- Composer
-- Node.js 18+ and npm
+- Composer 2+
+- Node.js 20+ and npm 10+
 
 ## Local Setup
 
 From the plugin root:
 
 ```bash
-composer install
-npm install
+make bootstrap
 npm run build
 ```
 
@@ -37,12 +36,20 @@ npm run start
 npm run build
 ```
 
+## Canonical task commands
+
+```bash
+make test
+make lint
+make lint-changed
+```
+
 ## Code Quality
 
 Run linters before opening a PR:
 
 ```bash
-npm run lint
+make lint
 ```
 
 Useful targeted commands:
@@ -52,6 +59,7 @@ npm run lint:js
 npm run lint:css
 npm run lint:php
 npm run lint:php:fix
+npm run lint:changed
 ```
 
 ## Tests
@@ -59,7 +67,7 @@ npm run lint:php:fix
 Run PHP unit tests:
 
 ```bash
-composer test
+make test
 ```
 
 Optional coverage run:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: bootstrap test lint lint-changed
+
+bootstrap:
+	bin/bootstrap
+
+test:
+	composer test
+
+lint:
+	npm run lint
+
+lint-changed:
+	npm run lint:changed

--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@ The AI for WordPress that actually does things
 ## Quick Start
 
 ```bash
-composer install
-npm install
+make bootstrap
 npm run build
+```
+
+## Common dev commands
+
+```bash
+make test
+make lint
+make lint-changed
 ```
 
 ## Key Features
@@ -115,7 +122,9 @@ Custom endpoints with permission callbacks and parameter validation.
 
 - PHP 8.1+
 - WordPress 6.9+
-- Node.js 18+
+- Composer 2+
+- Node.js 20+
+- npm 10+
 
 ## TODO
 

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[bootstrap] ClawPress environment bootstrap"
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "[bootstrap] Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+need_cmd php
+need_cmd composer
+need_cmd node
+need_cmd npm
+
+PHP_VERSION="$(php -r 'echo PHP_VERSION;')"
+NODE_VERSION="$(node -v)"
+
+echo "[bootstrap] PHP:  $PHP_VERSION (required >= 8.1)"
+echo "[bootstrap] Node: $NODE_VERSION (required >= 20)"
+
+php -r 'exit(version_compare(PHP_VERSION, "8.1", ">=") ? 0 : 1);' || {
+  echo "[bootstrap] PHP 8.1+ is required" >&2
+  exit 1
+}
+
+node -e 'const major=parseInt(process.versions.node.split(".")[0],10); process.exit(major>=20?0:1)' || {
+  echo "[bootstrap] Node.js 20+ is required" >&2
+  exit 1
+}
+
+echo "[bootstrap] Installing Composer dependencies"
+composer install --no-interaction --prefer-dist
+
+echo "[bootstrap] Installing npm dependencies"
+npm ci
+
+echo "[bootstrap] Done"

--- a/bin/lint-changed
+++ b/bin/lint-changed
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/develop}"
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  git fetch origin develop --depth=1
+fi
+
+CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE_REF"...HEAD)
+PHP_FILES=$(echo "$CHANGED" | grep -E '\.php$' || true)
+JS_FILES=$(echo "$CHANGED" | grep -E '\.(js|jsx|mjs|cjs)$' || true)
+
+if [[ -n "$PHP_FILES" ]]; then
+  # shellcheck disable=SC2086
+  vendor/bin/phpcs $PHP_FILES
+else
+  echo "No changed PHP files"
+fi
+
+if [[ -n "$JS_FILES" ]]; then
+  # shellcheck disable=SC2086
+  npx wp-scripts lint-js $JS_FILES
+else
+  echo "No changed JS files"
+fi

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:css": "wp-scripts lint-style",
     "lint:php": "composer lint",
     "lint:php:fix": "composer lint:fix",
+    "lint:changed": "bin/lint-changed",
     "composer:cleanup": "composer install --prefer-dist --optimize-autoloader --no-dev",
     "predeploy": "npm run lint && npm run build && npm run composer:cleanup",
     "deploy": "npm run plugin-zip"


### PR DESCRIPTION
Closes #6

## What changed
- Added `bin/bootstrap` to verify prerequisites and run:
  - `composer install`
  - `npm ci`
- Added canonical task runner targets in `Makefile`:
  - `make bootstrap`
  - `make test`
  - `make lint`
  - `make lint-changed`
- Added `bin/lint-changed` and `npm run lint:changed` to support changed-file lint task.
- Updated docs (`README.md`, `CONTRIBUTING.md`) with supported runtime versions and canonical commands.

## Runtime expectations documented
- PHP 8.1+
- WordPress 6.9+
- Composer 2+
- Node.js 20+
- npm 10+
